### PR TITLE
Set background session to be discretionary & to upload on WiFi only 

### DIFF
--- a/BridgeSDK/Networking/SBBNetworkManager.m
+++ b/BridgeSDK/Networking/SBBNetworkManager.m
@@ -251,6 +251,12 @@ NSString *kAPIPrefix = @"webservices";
       dispatch_once(&onceToken, ^{
         NSURLSessionConfiguration *config = [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:kBackgroundSessionIdentifier];
         bgSession = [NSURLSession sessionWithConfiguration:config delegate:self delegateQueue:nil];
+       
+        // Set the configuration to discretionary 
+        [config setDiscretionary: YES]; 
+         
+        // Set the configuration to run on Wi-Fi only 
+        config.allowsCellularAccess = NO; 
       });
       
       _backgroundSession = bgSession;

--- a/BridgeSDK/Networking/SBBNetworkManager.m
+++ b/BridgeSDK/Networking/SBBNetworkManager.m
@@ -250,13 +250,14 @@ NSString *kAPIPrefix = @"webservices";
       static dispatch_once_t onceToken;
       dispatch_once(&onceToken, ^{
         NSURLSessionConfiguration *config = [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:kBackgroundSessionIdentifier];
-        bgSession = [NSURLSession sessionWithConfiguration:config delegate:self delegateQueue:nil];
        
         // Set the configuration to discretionary 
         [config setDiscretionary: YES]; 
          
         // Set the configuration to run on Wi-Fi only 
         config.allowsCellularAccess = NO; 
+       
+        bgSession = [NSURLSession sessionWithConfiguration:config delegate:self delegateQueue:nil];
       });
       
       _backgroundSession = bgSession;


### PR DESCRIPTION
- Set the background session configuration to discretionary
- Set the background session to only allow uploads when on Wi-Fi